### PR TITLE
Removed disabling jumping acceleration in air

### DIFF
--- a/Assets/Scripts/Player/PlayerJumping.cs
+++ b/Assets/Scripts/Player/PlayerJumping.cs
@@ -28,13 +28,9 @@ namespace Player
         private static bool IsInputVerticalNegative => Input.GetAxisRaw("Vertical") < 0;
         private static bool IsInputVerticalPositive => Input.GetAxisRaw("Vertical") > 0;
 
-        private bool IsDistanceToAnyFloorForbidsChange
-        {
-            get
-            {
-                return FindObjectsOfType<WallDanger>().Any(wall => transform.GetDistanceTo(wall.gameObject)  < _forbidDirectionChangingDistance);
-            }
-        }
+        private bool IsDistanceToAnyFloorForbidsChange => 
+            FindObjectsOfType<WallDanger>()
+            .Any(wall => transform.GetDistanceTo(wall.gameObject) < _forbidDirectionChangingDistance);
 
         private void Start()
         {
@@ -66,9 +62,16 @@ namespace Player
 
         private void ApplyAcceleration()
         {
-            if (!_acceleratedFeatureEnabled ||_playerWallCollisions.IsGrounded || !Input.GetButtonDown("Jump")) return;
-            _rig.velocity *= _accelerated ? 1/_accelerationMultiplier : _accelerationMultiplier;
-            _accelerated = !_accelerated;
+            if (!_acceleratedFeatureEnabled || 
+                _playerWallCollisions.IsGrounded || 
+                !Input.GetButtonDown("Jump") || 
+                _accelerated)
+            {
+                return;
+            }
+
+            _rig.velocity *= _accelerationMultiplier;
+            _accelerated = true;
         }
         
         private void HandleJumping()

--- a/Assets/Scripts/Player/PlayerJumping.cs
+++ b/Assets/Scripts/Player/PlayerJumping.cs
@@ -14,7 +14,6 @@ namespace Player
         [SerializeField] private PlayerSounds _playerSounds;
         [SerializeField] private PlayerGravityHandler _gravityHandler;
         [SerializeField] private float _accelerationMultiplier = 2f;
-        [SerializeField] private bool _acceleratedFeatureEnabled;
         
         private bool _isJumpAxisWasIdle = true;
         private bool _directionWasChangedInJump;
@@ -62,13 +61,7 @@ namespace Player
 
         private void ApplyAcceleration()
         {
-            if (!_acceleratedFeatureEnabled || 
-                _playerWallCollisions.IsGrounded || 
-                !Input.GetButtonDown("Jump") || 
-                _accelerated)
-            {
-                return;
-            }
+            if (_playerWallCollisions.IsGrounded || !Input.GetButtonDown("Jump") || _accelerated) return;
 
             _rig.velocity *= _accelerationMultiplier;
             _accelerated = true;


### PR DESCRIPTION
I've found that acceleration stopping is hard to use consiously, but may confuse in very dynamic situation when player can occasionally press space again after applying acceleration